### PR TITLE
[EYE-104] Bluetooth scanning error handling and stop scanning fix

### DIFF
--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -58,7 +58,6 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
 
     return () => {
       bleService.stopScanForDevices();
-      console.log('SCANNING STOPPED');
     };
   }, [isFocused]);
 

--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { View, ScrollView, Text, TouchableOpacity, Alert } from 'react-native';
-import { useFocusEffect, useIsFocused } from '@react-navigation/native';
+import { View, ScrollView, Text, TouchableOpacity } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Device } from 'react-native-ble-plx';
 import { enc } from 'crypto-js';
@@ -25,8 +25,6 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
   const [allDevices, setAllDevices] = React.useState<Device[]>([]);
   const bleService = React.useContext(BLEContext);
 
-  const isFocused = useIsFocused();
-
   function getTitle(device: Device): string {
     if (device.manufacturerData == null) return 'Invalid Device';
     const base64CryptoWord = enc.Base64.parse(device.manufacturerData);
@@ -49,17 +47,21 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
     return `${device.name} - ${val.toString(16)}`;
   }
 
-  React.useEffect(() => {
+  const focusEffect = React.useCallback(() => {
     requestPermissions().then((isGranted: boolean) => {
       if (isGranted) {
         bleService.scanForDevices(setAllDevices);
+        console.log('START');
       }
     });
 
     return () => {
       bleService.stopScanForDevices();
+      console.log('STOP');
     };
-  }, [isFocused]);
+  }, []);
+
+  useFocusEffect(focusEffect);
 
   return (
     <View style={{ flex: 1 }}>

--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, ScrollView, Text, TouchableOpacity } from 'react-native';
+import { View, ScrollView, Text, TouchableOpacity, Alert } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Device } from 'react-native-ble-plx';
@@ -26,20 +26,18 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
   const bleService = React.useContext(BLEContext);
 
   function getTitle(device: Device): string {
-    if (device.manufacturerData == null) return "Invalid Device";
+    if (device.manufacturerData == null) return 'Invalid Device';
     const base64CryptoWord = enc.Base64.parse(device.manufacturerData);
     const hexStr = base64CryptoWord.toString(enc.Hex);
-       
+
     const bytes = [];
     for (let i = hexStr.length; i > 0; i -= 2) {
       bytes.push(parseInt(hexStr.substring(i - 2, i), 16));
     }
-    
-    if (bytes.length < 2 || 
-        bytes[bytes.length - 1] !== 0xFF || 
-        bytes[bytes.length - 2] !== 0xFF)
-      return "Invalid manufacturer";
-        
+
+    if (bytes.length < 2 || bytes[bytes.length - 1] !== 0xff || bytes[bytes.length - 2] !== 0xff)
+      return 'Invalid manufacturer';
+
     let val = 0;
     for (let i = 0; i < bytes.length - 2; i += 1) {
       val *= 0x100;
@@ -47,51 +45,65 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
     }
 
     return `${device.name} - ${val.toString(16)}`;
-  }     
+  }
 
   useFocusEffect(() => {
     requestPermissions().then((isGranted: boolean) => {
       if (isGranted) {
-        bleService.scanForDevices(setAllDevices);
+        try {
+          bleService.scanForDevices(setAllDevices);
+        } catch (err) {
+          console.log('test');
+        }
+      } else {
+        Alert.alert(
+          'Please allow location permissions for the app. This allows you to connect your camera to your mobile device.'
+        );
       }
     });
 
-    return () => {
-      bleService.stopScanForDevices();
-    };
+    // return () => {
+    //   bleService.stopScanForDevices();
+    // }
   });
 
   return (
     <View style={{ flex: 1 }}>
       <ScrollView>
-      <Text style={styles.registerCamText}> To register a camera, click on the desired camera in the list below This list will update automatically. </Text>
+        <Text style={styles.registerCamText}>
+          {' '}
+          To register a camera, click on the desired camera in the list below This list will update
+          automatically.{' '}
+        </Text>
         {allDevices
           .filter((dev) => dev.manufacturerData != null)
           .map((item) => (
-          <View key={item.manufacturerData}>
-            <TouchableOpacity
-              style={styles.registerCamButton} 
-              onPress={() => {
-                if (connecting) return;
-                setConnecting(true);
+            <View key={item.manufacturerData}>
+              <TouchableOpacity
+                style={styles.registerCamButton}
+                onPress={() => {
+                  if (connecting) return;
+                  setConnecting(true);
 
-                // This button will connect device
-                bleService
-                  .connectToDevice(item)
-                  .then(() => {
-                    setConnecting(false);
-                    navigation.navigate('CameraRegistrationInfo');
-                  })
-                  .catch((error) => {
-                    console.error(error);
-                    setConnecting(false);
-                  });
-              }}
-            >
-              <Text style={styles.registerCamButtonText}> {getTitle(item)} </Text>
-            </TouchableOpacity>
-          </View>
-        ))}
+                  // This button will connect device
+                  bleService
+                    .connectToDevice(item)
+                    .then(() => {
+                      // Connecting to camera was successful, so stop scanning
+                      setConnecting(false);
+                      bleService.stopScanForDevices();
+                      navigation.navigate('CameraRegistrationInfo');
+                    })
+                    .catch((error) => {
+                      console.error(error);
+                      setConnecting(false);
+                    });
+                }}
+              >
+                <Text style={styles.registerCamButtonText}> {getTitle(item)} </Text>
+              </TouchableOpacity>
+            </View>
+          ))}
       </ScrollView>
       {connecting && <LoadingIcon state={LoadingState.Loading} background />}
     </View>

--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -51,13 +51,11 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
     requestPermissions().then((isGranted: boolean) => {
       if (isGranted) {
         bleService.scanForDevices(setAllDevices);
-        console.log('START');
       }
     });
 
     return () => {
       bleService.stopScanForDevices();
-      console.log('STOP');
     };
   }, []);
 

--- a/app/human-detector-app/src/ble/bleServices.ts
+++ b/app/human-detector-app/src/ble/bleServices.ts
@@ -1,6 +1,5 @@
 import { BleError, Characteristic, Device, Subscription, BleManager } from 'react-native-ble-plx';
 import NetInfo from '@react-native-community/netinfo';
-import { useNavigation } from '@react-navigation/native';
 import * as EyeSpyUUID from '../../config/BLEConfig';
 import { base64ToJson, isDuplicateDevice, jsonToBase64, postBLEAlert } from './helpers';
 
@@ -70,8 +69,7 @@ export class BLEService {
    * scans for our specific devices.  It will also add it to a list which can be displayed to the user.
    */
   public scanForDevices(callback: (devices: Device[]) => void) {
-    // EyeSpyUUID.BLE_SERVICE_UUID
-    this.bleManager.startDeviceScan([], null, (error, device) => {
+    this.bleManager.startDeviceScan([EyeSpyUUID.BLE_SERVICE_UUID], null, (error, device) => {
       if (error) {
         console.error(error.message);
         postBLEAlert(error);

--- a/app/human-detector-app/src/ble/helpers.ts
+++ b/app/human-detector-app/src/ble/helpers.ts
@@ -1,5 +1,5 @@
-import { PermissionsAndroid, Platform } from 'react-native';
-import { Device } from 'react-native-ble-plx';
+import { PermissionsAndroid, Platform, Alert } from 'react-native';
+import { Device, BleError } from 'react-native-ble-plx';
 import { enc } from 'crypto-js';
 
 /**
@@ -9,58 +9,100 @@ import { enc } from 'crypto-js';
  */
 // eslint-disable-next-line import/prefer-default-export
 export async function requestPermissions(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-        const grantedStatus = await PermissionsAndroid.request(
-        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
-        {
-            title: 'Location Permission',
-            message: 'Bluetooth Low Energy Needs Location Permission',
-            buttonNegative: 'Cancel',
-            buttonPositive: 'Ok',
-            buttonNeutral: 'Maybe Later',
-        }
-        );
-        await PermissionsAndroid.requestMultiple([
-        PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
-        PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN
-        ]);
-        return grantedStatus === PermissionsAndroid.RESULTS.GRANTED;
-    }
+  if (Platform.OS === 'android') {
+    const grantedStatus = await PermissionsAndroid.request(
+      PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+      {
+        title: 'Location Permission',
+        message: 'Bluetooth Low Energy Needs Location Permission',
+        buttonNegative: 'Cancel',
+        buttonPositive: 'Ok',
+        buttonNeutral: 'Maybe Later',
+      }
+    );
+    await PermissionsAndroid.requestMultiple([
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+    ]);
+    return grantedStatus === PermissionsAndroid.RESULTS.GRANTED;
+  }
 
-    return true;
-};
+  return true;
+}
 
 /**
  * Converts an Object into it's base64 representation
- * 
+ *
  * @param obj JSON object to convert into base64
  * @returns Base64 encoded string
  */
 export function jsonToBase64(obj: any): string {
-    const jsonString = JSON.stringify(obj);
-    const cryptoWord = enc.Utf8.parse(jsonString);
-    return enc.Base64.stringify(cryptoWord);
+  const jsonString = JSON.stringify(obj);
+  const cryptoWord = enc.Utf8.parse(jsonString);
+  return enc.Base64.stringify(cryptoWord);
 }
 
 /**
  * Converts a base64 string into an object
- * 
+ *
  * @param val Base 64 string
  * @returns JSON object
  */
 export function base64ToJson(val: string): any {
-    const base64CryptoWord = enc.Base64.parse(val);
-    const jsonStr = base64CryptoWord.toString(enc.Utf8);
-    return JSON.parse(jsonStr);
+  const base64CryptoWord = enc.Base64.parse(val);
+  const jsonStr = base64CryptoWord.toString(enc.Utf8);
+  return JSON.parse(jsonStr);
 }
 
 /**
  * Checks for duplicate devices
- * 
+ *
  * @param devices devices list
  * @param nextDevice device to check for duplicate
  * @returns true if duplicate, false otherwise
  */
 export function isDuplicateDevice(devices: Device[], nextDevice: Device) {
-    return devices.findIndex((device) => nextDevice.id === device.id) > -1;
+  return devices.findIndex((device) => nextDevice.id === device.id) > -1;
+}
+
+/**
+ * Checks a BleError and sends an alert to the user.
+ *
+ * @param err the error we are checking
+ */
+
+export function postBLEAlert(err: BleError) {
+  switch (err.errorCode) {
+    case 100:
+      // 100: Bluetooth isn't supported on the device
+      Alert.alert(
+        'Bluetooth not supported!',
+        "Connecting a camera isn't supported without bluetooth."
+      );
+      break;
+
+    case 102:
+      // 102: Bluetooth connection on the mobile device is turned off
+      Alert.alert(
+        'Bluetooth is off!',
+        'Turn on bluetooth on your mobile device to connect a camera'
+      );
+      break;
+
+    case 600:
+      // 600: Scan start failed
+      Alert.alert('Bluetooth scanning failed', 'Please try again.');
+      break;
+
+    case 601:
+      // 602: If location services are turned off on the mobile device.
+      Alert.alert(
+        'Location services are off!',
+        'Enabling location services for the EyeSpy app is required to connect a camera.'
+      );
+      break;
+
+    default:
+      Alert.alert('Bluetooth error', err.message);
   }
+}


### PR DESCRIPTION
# Description

This PR fixes bugs EYE-102, EYE-104, EYE-109 and EYE-120.  I'll explain all of these below.

## EYE-102 and EYE-120

[EYE-120](https://eyespycamera.atlassian.net/jira/software/projects/EYE/boards/1?selectedIssue=EYE-120) and [EYE-102](https://eyespycamera.atlassian.net/jira/software/projects/EYE/boards/1?selectedIssue=EYE-102) were both fixed by the same changes.

These changes include changes to the `useFocusEffect` in the BluetoothScreen.  The hook `useFocusEffect()` would call its cleanup function on every re render of the app.  In other words, every time there is a new device and the app has to re render the list, the cleanup function with `stopScanForDevices()` will be run.  To fix this, I just wrapped the contents of the original `useFocusEffect` in `React.useCallback()` so the effect doesn't have to be created after every render.

This should fix EYE-102 as well because the device list will be cleared successfully **(pending testing)**.

More information about `useFocusEffect` [here](https://reactnavigation.org/docs/use-focus-effect/#:~:text=The%20useFocusEffect%20is%20analogous%20to%20React%27s%20useEffect%20hook.,on%20subsequent%20renders%20if%20the%20dependencies%20have%20changed.)

## [EYE-104](https://eyespycamera.atlassian.net/jira/software/projects/EYE/boards/1?selectedIssue=EYE-104) and [EYE-109](https://eyespycamera.atlassian.net/jira/software/projects/EYE/boards/1?selectedIssue=EYE-109)

Just some error handling for the common errors that were found during bug bashing and during my own local testing. Errors will pop up on an alert window if they occur during bluetooth scanning.  We probably need to handle Camera Registration errors too but that's not the scope of this bug.

## Testing

All local tests have been performed for EYE-104, EYE-109, and EYE-120.  ~~**EYE-102 is pending testing.  I can only test this once I'm on campus as I can't test at home.**~~. EDIT: EYE-102 will be done in a separate PR if needed since changes weren't directly influenced by this bug.

