### PR TITLE
Changed EAS Production Settings

### DIFF
--- a/app/human-detector-app/eas.json
+++ b/app/human-detector-app/eas.json
@@ -10,7 +10,11 @@
     "preview": {
       "distribution": "internal"
     },
-    "production": {}
+    "production": {
+      "android": {
+        "buildType": "apk"
+      }
+    }
   },
   "submit": {
     "production": {}


### PR DESCRIPTION
Made it so when making an EAS build, instead of a `.aab` file, it will generate a `.apk` file on build.  

This is made to prepare for mobile app deployment for next sprint.