### PR TITLE
[EYE-124] Notification screen revamp

### DIFF
--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -56,7 +56,7 @@ export default function App(): React.ReactElement {
         navigatorRef.isReady()
       ) {
         navigatorRef.navigate('Snapshot', {
-          snapshotId: notificationParse.data.notification.snapshotId,
+          snapshotId: notificationParse.data.snapshotId,
         });
       }
     });
@@ -113,7 +113,7 @@ export default function App(): React.ReactElement {
                         (cam) => cam.cameraId === pushNotificationData.cameraId
                       );
                       if (camera === undefined) {
-                        const notificationId = pushNotificationData.notification.id;
+                        const notificationId = pushNotificationData;
                         console.log(
                           `Received notification with ID "${notificationId}", which isn't associated with any known cameras.`
                         );
@@ -123,7 +123,7 @@ export default function App(): React.ReactElement {
                       // Don't notify again for a notification that has already been received
                       if (
                         camera.notifications.find(
-                          (notification) => notification.id === pushNotificationData.notification.id
+                          (notification) => notification.id === pushNotificationData.id
                         )
                       ) {
                         console.log('Ignoring notification', { pushNotificationData });
@@ -131,7 +131,7 @@ export default function App(): React.ReactElement {
                       }
 
                       // FIXME: this doesn't cause a re-render if the notification is received while on the notifications screen
-                      camera.notifications.push(pushNotificationData.notification);
+                      camera.notifications.push(pushNotificationData);
                       return {
                         shouldShowAlert: true,
                         shouldPlaySound: true,

--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -152,6 +152,9 @@ export default function App(): React.ReactElement {
   const user: User = backendService.getUser();
   user.groupList = groups;
 
+  // Put all the cameras in a map
+  user.makeCameraMapFromGroups();
+
   return (
     <NavigationContainer ref={navigatorRef}>
       <UserContext.Provider value={user}>

--- a/app/human-detector-app/__tests__/BackendService.test.ts
+++ b/app/human-detector-app/__tests__/BackendService.test.ts
@@ -75,7 +75,13 @@ describe(BackendService, () => {
             id: '473843',
             name: 'cameraname2',
             notifications: [
-              { id: '48374834', timestamp: '2022-06-14T03:24:00', snapshotId: 'test' },
+              {
+                id: '48374834',
+                timestamp: '2022-06-14T03:24:00',
+                snapshotId: 'test',
+                groupId: 'id',
+                cameraId: '473843',
+              },
             ],
           },
         ],
@@ -86,7 +92,7 @@ describe(BackendService, () => {
         new Group('group1', 'id', [
           new Camera('cameraname', '4324324', []),
           new Camera('cameraname2', '473843', [
-            new Notification('48374834', new Date('2022-06-14T03:24:00'), 'test'),
+            new Notification('48374834', new Date('2022-06-14T03:24:00'), 'test', 'id', '473843'),
           ]),
         ]),
       ];
@@ -120,8 +126,20 @@ describe(BackendService, () => {
       mockTokenManager.getUser.mockReturnValue(newUser);
 
       // make notification array
-      const notif1: Notification = new Notification('e', '2022-06-14T03:24:00', 'bee');
-      const notif2: Notification = new Notification('a', '2007-12-27T00:00:00', 'wawa');
+      const notif1: Notification = new Notification(
+        'e',
+        '2022-06-14T03:24:00',
+        'bee',
+        'groupId',
+        'cameraId'
+      );
+      const notif2: Notification = new Notification(
+        'a',
+        '2007-12-27T00:00:00',
+        'wawa',
+        'groupId',
+        'cameraId'
+      );
 
       const notifHistory: Notification[] = [notif1, notif2];
 

--- a/app/human-detector-app/classes/Group.tsx
+++ b/app/human-detector-app/classes/Group.tsx
@@ -16,6 +16,13 @@ export default class Group {
     this.cameras = cameras;
   }
 
+  getCameraFromId(cameraId: string): Camera | undefined {
+    if (this.cameras.find((camera) => camera.cameraId === cameraId)) {
+      return this.cameras.find((camera) => camera.cameraId === cameraId);
+    }
+    throw new Error("Group doesn't exist!");
+  }
+
   addCameraToGroup(newCam: Camera) {
     this.cameras.push(newCam);
   }

--- a/app/human-detector-app/classes/Group.tsx
+++ b/app/human-detector-app/classes/Group.tsx
@@ -16,13 +16,6 @@ export default class Group {
     this.cameras = cameras;
   }
 
-  getCameraFromId(cameraId: string): Camera | undefined {
-    if (this.cameras.find((camera) => camera.cameraId === cameraId)) {
-      return this.cameras.find((camera) => camera.cameraId === cameraId);
-    }
-    throw new Error("Group doesn't exist!");
-  }
-
   addCameraToGroup(newCam: Camera) {
     this.cameras.push(newCam);
   }

--- a/app/human-detector-app/classes/Notification.ts
+++ b/app/human-detector-app/classes/Notification.ts
@@ -7,20 +7,22 @@ export default class Notification {
 
   snapshotId: string;
 
-  constructor(id: string, timestamp: Date, snapshotId: string) {
+  groupId: string;
+
+  cameraId: string;
+
+  constructor(id: string, timestamp: Date, snapshotId: string, groupId: string, cameraId: string) {
     this.id = id;
     this.timestamp = timestamp;
     this.snapshotId = snapshotId;
+    this.groupId = groupId;
+    this.cameraId = cameraId;
   }
 }
 
-export const zNotification = z
-  .object({
-    id: z.string().uuid(),
-    timestamp: z.string(), // FIXME: validate that this is a date
-    snapshotId: z.string().uuid(),
-  })
-  .transform(
-    (zodNotif) => new Notification(zodNotif.id, new Date(zodNotif.timestamp), zodNotif.snapshotId)
-  );
+export const zNotification = z.object({
+  id: z.string().uuid(),
+  timestamp: z.string(), // FIXME: validate that this is a date
+  snapshotId: z.string().uuid(),
+});
 export type ZNotification = z.infer<typeof zNotification>;

--- a/app/human-detector-app/classes/PushNotificationData.ts
+++ b/app/human-detector-app/classes/PushNotificationData.ts
@@ -1,9 +1,20 @@
 import { z } from 'zod';
-import { zNotification } from './Notification';
+import Notification, { zNotification } from './Notification';
 
-export const zPushNotificationData = z.object({
-  groupId: z.string().uuid(),
-  cameraId: z.string().uuid(),
-  notification: zNotification,
-});
+export const zPushNotificationData = z
+  .object({
+    groupId: z.string().uuid(),
+    cameraId: z.string().uuid(),
+    notification: zNotification,
+  })
+  .transform(
+    (zodNotif) =>
+      new Notification(
+        zodNotif.notification.id,
+        new Date(zodNotif.notification.timestamp),
+        zodNotif.notification.snapshotId,
+        zodNotif.groupId,
+        zodNotif.cameraId
+      )
+  );
 export type ZPushNotificationData = z.infer<typeof zPushNotificationData>;

--- a/app/human-detector-app/classes/User.tsx
+++ b/app/human-detector-app/classes/User.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable array-callback-return */
 
 import Group from './Group';
+import Camera from './Camera';
 import Notification from './Notification';
 
 export default class User {
@@ -11,10 +12,13 @@ export default class User {
 
   groupList: Group[];
 
+  cameraMap: Map<string, Camera>;
+
   constructor(username: string, userId: string, groupList: Group[]) {
     this.username = username;
     this.userId = userId; // Should always be from authorization token
     this.groupList = groupList;
+    this.cameraMap = new Map<string, Camera>();
   }
 
   getGroupFromId(groupId: string): Group | undefined {
@@ -47,5 +51,13 @@ export default class User {
       });
     });
     return notifs;
+  }
+
+  makeCameraMapFromGroups(): void {
+    this.groupList.map((group) => {
+      group.cameras.map((cam) => {
+        this.cameraMap.set(cam.cameraId, cam);
+      });
+    });
   }
 }

--- a/app/human-detector-app/classes/User.tsx
+++ b/app/human-detector-app/classes/User.tsx
@@ -15,10 +15,9 @@ export default class User {
     this.username = username;
     this.userId = userId; // Should always be from authorization token
     this.groupList = groupList;
-    
   }
 
-  getGroupFromId(groupId: string) {
+  getGroupFromId(groupId: string): Group | undefined {
     if (this.groupList.find((group) => group.groupId === groupId)) {
       return this.groupList.find((group) => group.groupId === groupId);
     }
@@ -38,16 +37,15 @@ export default class User {
   }
 
   getAllNotifications(): Notification[] {
-    const notifs: Notification[] = []
+    const notifs: Notification[] = [];
 
     this.groupList.map((group) => {
       group.cameras.map((cam) => {
         cam.notifications.map((notif) => {
           notifs.push(notif);
-        })
-      })
-    })
+        });
+      });
+    });
     return notifs;
   }
-
 }

--- a/app/human-detector-app/classes/User.tsx
+++ b/app/human-detector-app/classes/User.tsx
@@ -54,8 +54,8 @@ export default class User {
   }
 
   makeCameraMapFromGroups(): void {
-    this.groupList.map((group) => {
-      group.cameras.map((cam) => {
+    this.groupList.forEach((group) => {
+      group.cameras.forEach((cam) => {
         this.cameraMap.set(cam.cameraId, cam);
       });
     });

--- a/app/human-detector-app/screens/CameraRegistration/EnterCameraRegInfoScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/EnterCameraRegInfoScreen.tsx
@@ -77,8 +77,12 @@ export default function EnterCameraRegInfoScreen({ navigation, route }: Props): 
           console.error(error);
           navigation.navigate('BluetoothDeviceList');
         });
-        userContext.getGroupFromId(groupId)?.cameras.push(new Camera(cameraName, uuid, []));
+        const newCam = new Camera(cameraName, uuid, []);
+
+        userContext.getGroupFromId(groupId)?.cameras.push(newCam);
         navigation.navigate('Loading');
+
+        userContext.cameraMap.set(newCam.cameraId, newCam);
       })
       .catch((error) => {
         console.error(error);

--- a/app/human-detector-app/screens/NotifScreen.tsx
+++ b/app/human-detector-app/screens/NotifScreen.tsx
@@ -38,11 +38,7 @@ export default function NotifScreen({ navigation, route }: Props): React.ReactEl
                   {notification.timestamp.toLocaleTimeString(undefined, { hour12: true })}
                 </Text>
                 <Text style={styles.cameraNameText} numberOfLines={1}>
-                  {
-                    userContext
-                      .getGroupFromId(notification.groupId)
-                      ?.getCameraFromId(notification.cameraId)?.cameraName
-                  }
+                  {userContext.cameraMap.get(notification.cameraId)?.cameraName}
                 </Text>
               </View>
             </TouchableOpacity>

--- a/app/human-detector-app/screens/NotifScreen.tsx
+++ b/app/human-detector-app/screens/NotifScreen.tsx
@@ -3,6 +3,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Text, ScrollView, View, TouchableOpacity } from 'react-native';
 import { RootStackParamList } from '../src/navigation/stackParamList';
 import { styles } from '../src/styles';
+import { UserContext } from '../contexts/userContext';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Notifications'>;
 
@@ -11,20 +12,39 @@ export default function NotifScreen({ navigation, route }: Props): React.ReactEl
   const sortedNotifications = notifications.sort(
     (a, b) => b.timestamp.getTime() - a.timestamp.getTime()
   );
+
+  const userContext = React.useContext(UserContext);
+
+  if (!userContext) {
+    throw new Error('UserContext not found!');
+  }
+
   return (
     <View style={styles.container}>
       <ScrollView>
         {sortedNotifications.map((notification) => (
           <View key={notification.id}>
             <TouchableOpacity
-              style={styles.menuItem}
+              style={styles.notificationMenuItem}
               onPress={() => {
                 navigation.navigate('Snapshot', { snapshotId: notification.snapshotId });
               }}
             >
-              <Text style={styles.menuButtonText}>
-                {notification.timestamp.toLocaleString(undefined, { hour12: true })}
+              <Text style={styles.dateText}>
+                {notification.timestamp.toLocaleDateString(undefined)}
               </Text>
+              <View style={styles.notificationBottomText}>
+                <Text style={styles.notificationTimeText}>
+                  {notification.timestamp.toLocaleTimeString(undefined, { hour12: true })}
+                </Text>
+                <Text style={styles.cameraNameText} numberOfLines={1}>
+                  {
+                    userContext
+                      .getGroupFromId(notification.groupId)
+                      ?.getCameraFromId(notification.cameraId)?.cameraName
+                  }
+                </Text>
+              </View>
             </TouchableOpacity>
           </View>
         ))}

--- a/app/human-detector-app/services/backendService.ts
+++ b/app/human-detector-app/services/backendService.ts
@@ -189,7 +189,14 @@ export default class BackendService {
       // TODO: Get notification array
       const newCamArr = group.cameras.map((cam: any) => {
         const newNotifArr = cam.notifications.map(
-          (notif: any) => new Notification(notif.id, new Date(notif.timestamp), notif.snapshotId)
+          (notif: any) =>
+            new Notification(
+              notif.id,
+              new Date(notif.timestamp),
+              notif.snapshotId,
+              group.id,
+              cam.id
+            )
         );
         return new Camera(cam.name, cam.id, newNotifArr);
       });

--- a/app/human-detector-app/src/styles.ts
+++ b/app/human-detector-app/src/styles.ts
@@ -104,4 +104,33 @@ export const styles = StyleSheet.create({
     marginTop: 200,
     color: '#696969',
   },
+  notificationMenuItem: {
+    padding: 10,
+    backgroundColor: '#EDEDED',
+    fontSize: 24,
+    borderWidth: 1,
+    borderColor: '#D3D3D3',
+  },
+  dateText: {
+    fontSize: 20,
+    padding: 0,
+  },
+  notificationTimeText: {
+    flex: 1,
+    textAlign: 'left',
+    fontSize: 16,
+    color: '#949292',
+  },
+  notificationBottomText: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  cameraNameText: {
+    flex: 1,
+    fontWeight: 'bold',
+    fontSize: 14,
+    textAlign: 'right',
+  },
 });


### PR DESCRIPTION
# Description

This PR revamps the notification screen to look better.  This involves restyling the menu items on the notification screen. 
This also makes it so that the camera name pops up on the notification.  This is mainly for the all notifications screen where the user won't know what camera a notification is in until the user clicks on it.

I don't really like how I have it set up right now (and I'm not sure how I'm going to test the post notification stuff since my phone doesn't work with notifications as for as we've tested???).  Therefore, most of the changes that I have done with zod and type inference I have no way to confirm or deny if its working right now. 

On my other changes, I added `groupId` and `cameraId` to the Notification class so that from the notification screen, we can get the camera name "easily" to print on the notification menu item.  "Easily" as in it is incredibly inefficient since we're searching through many arrays to get to the camera name.  **Should we change this so that the Notification has a parameter for a Camera object or would that be too much of a change?**   I don't really like the groupId just sitting there because it goes against what my brain says lol.

This is what the new items look like on the screen (couldn't get updated screenshots).

**Final format for date is MM/DD/YYYY
Final format for time is HH:MM:SS AM/PM**

![image](https://user-images.githubusercontent.com/77024792/214523249-53184849-a5f3-4423-8791-51e6c9925dad.png)


## Testing

Upon local testing, everything works as expected.  However, going to any notification screen (especially the all notification screen) has slowed down a bit.  Since as that list gets larger, it will exponentially become longer to load that page so this is kind of why I want to ask before I go any further in this stuff.  

## JIRA Ticket Link
https://eyespycamera.atlassian.net/jira/software/projects/EYE/boards/1?selectedIssue=EYE-124