### PR TITLE
[EYE-105] Fixed non-serializable bug

### DIFF
--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -177,7 +177,7 @@ export default function App(): React.ReactElement {
                     color="white"
                     onPress={() => {
                       navigation.navigate('Notifications', {
-                        notifications: user.getAllNotifications(),
+                        cams: [...user.cameraMap.keys()],
                       });
                     }}
                   />

--- a/app/human-detector-app/__tests__/BackendService.test.ts
+++ b/app/human-detector-app/__tests__/BackendService.test.ts
@@ -92,7 +92,7 @@ describe(BackendService, () => {
         new Group('group1', 'id', [
           new Camera('cameraname', '4324324', []),
           new Camera('cameraname2', '473843', [
-            new Notification('48374834', new Date('2022-06-14T03:24:00'), 'test', 'id', '473843'),
+            new Notification('48374834', new Date('2022-06-14T03:24:00'), 'test', '473843'),
           ]),
         ]),
       ];
@@ -126,20 +126,8 @@ describe(BackendService, () => {
       mockTokenManager.getUser.mockReturnValue(newUser);
 
       // make notification array
-      const notif1: Notification = new Notification(
-        'e',
-        '2022-06-14T03:24:00',
-        'bee',
-        'groupId',
-        'cameraId'
-      );
-      const notif2: Notification = new Notification(
-        'a',
-        '2007-12-27T00:00:00',
-        'wawa',
-        'groupId',
-        'cameraId'
-      );
+      const notif1: Notification = new Notification('e', '2022-06-14T03:24:00', 'bee', 'cameraId');
+      const notif2: Notification = new Notification('a', '2007-12-27T00:00:00', 'wawa', 'cameraId');
 
       const notifHistory: Notification[] = [notif1, notif2];
 

--- a/app/human-detector-app/classes/Notification.ts
+++ b/app/human-detector-app/classes/Notification.ts
@@ -7,15 +7,12 @@ export default class Notification {
 
   snapshotId: string;
 
-  groupId: string;
-
   cameraId: string;
 
-  constructor(id: string, timestamp: Date, snapshotId: string, groupId: string, cameraId: string) {
+  constructor(id: string, timestamp: Date, snapshotId: string, cameraId: string) {
     this.id = id;
     this.timestamp = timestamp;
     this.snapshotId = snapshotId;
-    this.groupId = groupId;
     this.cameraId = cameraId;
   }
 }

--- a/app/human-detector-app/classes/PushNotificationData.ts
+++ b/app/human-detector-app/classes/PushNotificationData.ts
@@ -13,7 +13,6 @@ export const zPushNotificationData = z
         zodNotif.notification.id,
         new Date(zodNotif.notification.timestamp),
         zodNotif.notification.snapshotId,
-        zodNotif.groupId,
         zodNotif.cameraId
       )
   );

--- a/app/human-detector-app/classes/User.tsx
+++ b/app/human-detector-app/classes/User.tsx
@@ -40,15 +40,19 @@ export default class User {
     return groupRemoved;
   }
 
-  getAllNotifications(): Notification[] {
+  getNotifsFromCams(camIdArray: string[]): Notification[] {
     const notifs: Notification[] = [];
 
-    this.groupList.map((group) => {
-      group.cameras.map((cam) => {
-        cam.notifications.map((notif) => {
+    camIdArray.forEach((camId) => {
+      const notifsFromCamera = this.cameraMap.get(camId)?.notifications;
+
+      if (notifsFromCamera) {
+        notifsFromCamera.forEach((notif) => {
           notifs.push(notif);
         });
-      });
+      } else {
+        console.error(`${camId} not found in the camera map`);
+      }
     });
     return notifs;
   }

--- a/app/human-detector-app/screens/CameraScreen.tsx
+++ b/app/human-detector-app/screens/CameraScreen.tsx
@@ -32,7 +32,7 @@ export default function CameraScreen({ navigation, route }: Props): React.ReactE
               style={styles.menuItem}
               onPress={() => {
                 navigation.navigate('Notifications', {
-                  notifications: item.notifications,
+                  cams: [item.cameraId],
                 });
               }}
             >

--- a/app/human-detector-app/screens/NotifScreen.tsx
+++ b/app/human-detector-app/screens/NotifScreen.tsx
@@ -8,16 +8,19 @@ import { UserContext } from '../contexts/userContext';
 type Props = NativeStackScreenProps<RootStackParamList, 'Notifications'>;
 
 export default function NotifScreen({ navigation, route }: Props): React.ReactElement<Props> {
-  const { notifications } = route.params;
-  const sortedNotifications = notifications.sort(
-    (a, b) => b.timestamp.getTime() - a.timestamp.getTime()
-  );
-
   const userContext = React.useContext(UserContext);
-
   if (!userContext) {
     throw new Error('UserContext not found!');
   }
+
+  const { cams } = route.params;
+  const notifications = userContext.getNotifsFromCams(cams);
+
+  // Date object to be used to compare if the current day is today
+  const today = new Date();
+  const sortedNotifications = notifications.sort(
+    (a, b) => b.timestamp.getTime() - a.timestamp.getTime()
+  );
 
   return (
     <View style={styles.container}>
@@ -31,11 +34,20 @@ export default function NotifScreen({ navigation, route }: Props): React.ReactEl
               }}
             >
               <Text style={styles.dateText}>
-                {notification.timestamp.toLocaleDateString(undefined)}
+                {today.toLocaleDateString(undefined) ===
+                notification.timestamp.toLocaleDateString(undefined)
+                  ? 'Today'
+                  : notification.timestamp.toLocaleDateString(undefined, {
+                      month: 'long',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
               </Text>
               <View style={styles.notificationBottomText}>
                 <Text style={styles.notificationTimeText}>
-                  {notification.timestamp.toLocaleTimeString(undefined, { hour12: true })}
+                  {notification.timestamp.toLocaleTimeString(undefined, {
+                    hour12: true,
+                  })}
                 </Text>
                 <Text style={styles.cameraNameText} numberOfLines={1}>
                   {userContext.cameraMap.get(notification.cameraId)?.cameraName}

--- a/app/human-detector-app/screens/NotifScreen.tsx
+++ b/app/human-detector-app/screens/NotifScreen.tsx
@@ -18,6 +18,7 @@ export default function NotifScreen({ navigation, route }: Props): React.ReactEl
 
   // Date object to be used to compare if the current day is today
   const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const sortedNotifications = notifications.sort(
     (a, b) => b.timestamp.getTime() - a.timestamp.getTime()
   );
@@ -34,8 +35,7 @@ export default function NotifScreen({ navigation, route }: Props): React.ReactEl
               }}
             >
               <Text style={styles.dateText}>
-                {today.toLocaleDateString(undefined) ===
-                notification.timestamp.toLocaleDateString(undefined)
+                {notification.timestamp.getTime() - today.getTime() > 0
                   ? 'Today'
                   : notification.timestamp.toLocaleDateString(undefined, {
                       month: 'long',

--- a/app/human-detector-app/services/backendService.ts
+++ b/app/human-detector-app/services/backendService.ts
@@ -190,13 +190,7 @@ export default class BackendService {
       const newCamArr = group.cameras.map((cam: any) => {
         const newNotifArr = cam.notifications.map(
           (notif: any) =>
-            new Notification(
-              notif.id,
-              new Date(notif.timestamp),
-              notif.snapshotId,
-              group.id,
-              cam.id
-            )
+            new Notification(notif.id, new Date(notif.timestamp), notif.snapshotId, cam.id)
         );
         return new Camera(cam.name, cam.id, newNotifArr);
       });

--- a/app/human-detector-app/src/navigation/stackParamList.tsx
+++ b/app/human-detector-app/src/navigation/stackParamList.tsx
@@ -1,13 +1,12 @@
 import { NavigatorScreenParams } from '@react-navigation/native';
 import { BLEParamList } from './bleParamList';
 import { GroupRegParamList } from './groupRegParamList';
-import Notification from '../../classes/Notification';
 
 export type RootStackParamList = {
   Login: undefined;
   Groups: undefined;
   Cameras: { groupId: string };
-  Notifications: { notifications: Notification[] };
+  Notifications: { cams: string[] };
   Snapshot: { snapshotId: string };
   CameraRegistration: { groupId: string; paramList: NavigatorScreenParams<BLEParamList> };
   GroupRegistration: NavigatorScreenParams<GroupRegParamList>;


### PR DESCRIPTION
# Description

Made changes to the notification screen so that when a user is taken to that screen, non-serializable warnings wouldn't occur.  This was done by throwing camera ids to the notification screen since we're always gonna be getting all of a cameras notifications at the very least.  I also included small changes like long month printing on each notification.

## Testing

Everything works as expected and the warnings don't pop up anymore.

## JIRA Ticket Link
https://eyespycamera.atlassian.net/jira/software/projects/EYE/boards/1?selectedIssue=EYE-105