### PR TITLE
Delete wifi connection and internal keys on failure

### DIFF
--- a/camera/auth/src/eyespy_service.py
+++ b/camera/auth/src/eyespy_service.py
@@ -64,7 +64,8 @@ class EyeSpyService:
             if new_reason == FailReason.BACKEND_DOWN:
                 self.on_camera_state_change(CameraState.BACKEND_DOWN)
             elif ((self.state == CameraState.BOOT and time() - self.boot_time > START_TIMEOUT)
-                or new_reason == FailReason.FORBIDDEN):
+                or new_reason == FailReason.FORBIDDEN
+                or new_reason == FailReason.INCORRECT_SECRETS):
                 self.on_camera_state_change(CameraState.BLE_UP)
                 self.keys.clear_keys()
 

--- a/camera/auth/src/eyespy_service.py
+++ b/camera/auth/src/eyespy_service.py
@@ -66,8 +66,11 @@ class EyeSpyService:
             elif ((self.state == CameraState.BOOT and time() - self.boot_time > START_TIMEOUT)
                 or new_reason == FailReason.FORBIDDEN
                 or new_reason == FailReason.INCORRECT_SECRETS):
-                self.on_camera_state_change(CameraState.BLE_UP)
+                # Remove configuration if fail to connect
+                # This factory resets the camera
                 self.keys.clear_keys()
+                self.wifi.delete_old_config()
+                self.on_camera_state_change(CameraState.BLE_UP)
 
         elif new_state == WifiState.ATTEMPTING_PING:
             self.heartbeat.stop()

--- a/camera/auth/src/eyespy_service.py
+++ b/camera/auth/src/eyespy_service.py
@@ -61,9 +61,11 @@ class EyeSpyService:
             # We wait a bit during boot before allowing a failure to cause a state change
             # in case the PI is booting from a power outage (and the wifi router is slow)
             # or some other weird state
+            timedout = time() - self.boot_time > START_TIMEOUT and self.state == CameraState.BOOT
+
             if new_reason == FailReason.BACKEND_DOWN:
                 self.on_camera_state_change(CameraState.BACKEND_DOWN)
-            elif ((self.state == CameraState.BOOT and time() - self.boot_time > START_TIMEOUT)
+            elif ((timedout and new_reason == FailReason.SSID_NOT_FOUND)
                 or new_reason == FailReason.FORBIDDEN
                 or new_reason == FailReason.INCORRECT_SECRETS):
                 # Remove configuration if fail to connect

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "human-detector",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "human-detector",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Only new behavior is to delete keys if the failure reason is `Incorrect_Secrets`. The last remaining failure reason is `NO_SSID`, but I made it explicit here to be clearer.